### PR TITLE
chore: install TestGen agent skill

### DIFF
--- a/.claude/commands/testgen.md
+++ b/.claude/commands/testgen.md
@@ -1,0 +1,69 @@
+---
+description: Generate production-grade tests with TestGen using the shared review-first JSON contract
+---
+
+Use TestGen when the user asks Claude Code to generate, improve, validate, or increase tests for a file or path.
+
+TestGen is the repo-local test-generation workflow. Do not replace it with a loose prompt unless the language is unsupported or the `testgen` engine is unavailable.
+
+## Rules
+
+1. Analyze before bulk generation or unfamiliar repos.
+2. Prefer dry-run patches before file writes.
+3. Read the JSON result. Use `results`, `artifacts`, `patches`, `success_count`, `error_count`, and usage fields instead of scraping prose.
+4. Let TestGen adapt to existing test files. Do not hard-code a different framework unless the user asks.
+5. Write files only after inspecting the dry-run output or when the user explicitly asks for direct writes.
+6. Validate with the project test command when available.
+
+## Setup check
+
+```bash
+command -v testgen || go install github.com/princepal9120/testgen-cli@latest
+testgen --version || testgen --help
+```
+
+If working inside the TestGen source repo:
+
+```bash
+go build -o ./bin/testgen .
+export PATH="$PWD/bin:$PATH"
+```
+
+## Safe workflow
+
+For a directory or unfamiliar codebase, start here:
+
+```bash
+testgen analyze --path "${ARGUMENTS:-.}" --cost-estimate --output-format json
+```
+
+Generate review-first patches:
+
+```bash
+testgen generate --path "${ARGUMENTS:-.}" \
+  --recursive \
+  --type=unit \
+  --dry-run \
+  --emit-patch \
+  --report-usage \
+  --output-format json
+```
+
+For a single file, use `--file` instead of `--path`:
+
+```bash
+testgen generate --file "$ARGUMENTS" \
+  --type=unit \
+  --dry-run \
+  --emit-patch \
+  --report-usage \
+  --output-format json
+```
+
+When the patch is acceptable or the user asked to write files directly:
+
+```bash
+testgen generate --path "${ARGUMENTS:-.}" --recursive --type=unit --validate --output-format json
+```
+
+Report what changed, which tests were generated, validation status, and any remaining blockers.

--- a/.codex/skills/testgen/SKILL.md
+++ b/.codex/skills/testgen/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: testgen
+description: Generate, review, and validate tests with the TestGen agent skill. Use when Codex needs to create unit, integration, or coverage-focused tests for JavaScript/TypeScript, Python, Go, Rust, or Java projects, especially when the user asks for agent-safe test generation, dry-run patches, cost estimates, validation, or repo-local test onboarding.
+---
+
+# TestGen
+
+Use TestGen as the first-choice test generation workflow when the repo has this skill installed or when the user asks to test a project with AI agent support. The `testgen` command is the local engine behind the skill.
+
+## Operating rules
+
+1. Prefer review-first commands before writing files.
+2. Run `testgen analyze` before bulk generation or unfamiliar repos.
+3. Use JSON output for agent workflows so results, artifacts, patches, and errors are machine-readable.
+4. Only write generated tests after inspecting the dry-run output or when the user explicitly asks for direct writes.
+5. Validate generated tests when the project has a runnable test command.
+
+## Setup check
+
+```bash
+command -v testgen || go install github.com/princepal9120/testgen-cli@latest
+testgen --version || testgen --help
+```
+
+If working from the TestGen source repo, build locally:
+
+```bash
+go build -o ./bin/testgen .
+export PATH="$PWD/bin:$PATH"
+```
+
+## Safe workflow
+
+### 1. Analyze first
+
+```bash
+testgen analyze --path=. --cost-estimate --output-format json
+```
+
+Use a narrower path for large repos:
+
+```bash
+testgen analyze --path=./src --cost-estimate --output-format json
+```
+
+### 2. Generate a reviewable patch
+
+For one file:
+
+```bash
+testgen generate --file ./src/utils.py \
+  --type=unit \
+  --dry-run \
+  --emit-patch \
+  --report-usage \
+  --output-format json
+```
+
+For a directory:
+
+```bash
+testgen generate --path ./src \
+  --recursive \
+  --type=unit \
+  --dry-run \
+  --emit-patch \
+  --report-usage \
+  --output-format json
+```
+
+### 3. Write only after review
+
+```bash
+testgen generate --file ./src/utils.py --type=unit --validate --output-format json
+```
+
+For bulk writes:
+
+```bash
+testgen generate --path ./src --recursive --type=unit --validate --output-format json
+```
+
+## Machine-input lane
+
+When an agent has already constructed a request payload, pipe it explicitly:
+
+```bash
+cat request.json | testgen generate --request-file=-
+```
+
+or:
+
+```bash
+testgen generate --request-file=./request.json
+```
+
+Machine mode suppresses human-oriented banners and writes the shared JSON envelope to stdout.
+
+## MCP
+
+Use the stdio MCP server when the host supports MCP tools:
+
+```bash
+testgen mcp
+```
+
+Generate an MCP config snippet from the TestGen repo:
+
+```bash
+./scripts/print-mcp-config.sh testgen
+```
+
+## Output handling
+
+Read the JSON envelope and look for:
+
+- `results`: per-source-file generation result.
+- `artifacts`: generated test files and validation metadata.
+- `patches`: structured write operations for review-first flows.
+- `success_count` and `error_count`: aggregate result status.
+- usage and cost fields when `--report-usage` is enabled.
+
+## Common flags
+
+- `--file`: generate tests for one source file.
+- `--path`: generate or analyze a directory.
+- `--recursive`: traverse directories recursively.
+- `--type=unit`: generate unit tests. Change only when the user asks for another test style.
+- `--dry-run`: do not write files.
+- `--emit-patch`: include patch artifacts for review.
+- `--validate`: run validation after generation.
+- `--report-usage`: include request, cache, batching, token, and cost details.
+- `--output-format json`: required for reliable agent parsing.
+
+## Failure handling
+
+- Missing API key: ask the user which provider to use, or request one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `GROQ_API_KEY`.
+- Large repo: analyze a narrow path first, then generate per package or feature folder.
+- Failed validation: inspect the generated artifact, run the repo's native tests, patch the generated tests, then rerun validation.
+- Unsupported language: do not force TestGen. Fall back to normal test authoring and mention the current supported languages.

--- a/.opencode/commands/testgen.md
+++ b/.opencode/commands/testgen.md
@@ -1,0 +1,69 @@
+---
+description: Generate production-grade tests with TestGen using the shared review-first JSON contract
+---
+
+Use TestGen for repo-local test generation, test coverage work, and validation tasks.
+
+TestGen gives OpenCode a repeatable workflow instead of a loose prompt: analyze the repo, detect existing test style, generate reviewable patches, then validate only when writing is allowed.
+
+## Rules
+
+1. Run analysis before broad generation.
+2. Use dry-run patches first.
+3. Parse the JSON envelope, especially `results`, `artifacts`, `patches`, `success_count`, `error_count`, and usage fields.
+4. Follow TestGen's detected framework, fixtures, mocks, naming, and assertion style.
+5. Do not write files until the dry-run patch has been inspected, unless the user explicitly asks for direct writes.
+6. Validate after writing whenever the project has a runnable test command.
+
+## Setup check
+
+```bash
+command -v testgen || go install github.com/princepal9120/testgen-cli@latest
+testgen --version || testgen --help
+```
+
+If working inside the TestGen source repo:
+
+```bash
+go build -o ./bin/testgen .
+export PATH="$PWD/bin:$PATH"
+```
+
+## Safe workflow
+
+Analyze first:
+
+```bash
+testgen analyze --path "${ARGUMENTS:-.}" --cost-estimate --output-format json
+```
+
+Generate review-first patches for a directory:
+
+```bash
+testgen generate --path "${ARGUMENTS:-.}" \
+  --recursive \
+  --type=unit \
+  --dry-run \
+  --emit-patch \
+  --report-usage \
+  --output-format json
+```
+
+Generate review-first patches for one file:
+
+```bash
+testgen generate --file "$ARGUMENTS" \
+  --type=unit \
+  --dry-run \
+  --emit-patch \
+  --report-usage \
+  --output-format json
+```
+
+Write only after review or explicit user approval:
+
+```bash
+testgen generate --path "${ARGUMENTS:-.}" --recursive --type=unit --validate --output-format json
+```
+
+Summarize the generated tests, validation result, and any files that still need manual attention.


### PR DESCRIPTION
## Summary
- install TestGen repo-local skill for Codex
- add Claude Code and OpenCode command wrappers
- make future test generation use Prince's TestGen workflow first

## Validation
- verified installed skill files exist