### PR TITLE
test: add security helper coverage via TestGen

### DIFF
--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,56 @@
+import base64
+import hashlib
+import hmac
+
+from app.core import security
+
+
+def test_generate_confirmation_code_returns_uppercase_8_char_hex_code():
+    code = security.generate_confirmation_code()
+
+    assert len(code) == 8
+    assert code == code.upper()
+    int(code, 16)
+
+
+def test_generate_confirmation_code_produces_different_values():
+    codes = {security.generate_confirmation_code() for _ in range(8)}
+
+    assert len(codes) > 1
+
+
+def test_verify_twilio_signature_accepts_valid_signature():
+    url = "https://example.com/webhook"
+    body = {"CallSid": "CA123", "From": "+15551234567"}
+    token = "test-token"
+    data = url + "".join(f"{key}{value}" for key, value in sorted(body.items()))
+    signature = base64.b64encode(
+        hmac.new(token.encode(), data.encode(), hashlib.sha1).digest()
+    ).decode()
+
+    assert security.verify_twilio_signature(url, body, signature, auth_token=token) is True
+
+
+def test_verify_twilio_signature_rejects_invalid_signature():
+    assert (
+        security.verify_twilio_signature(
+            "https://example.com/webhook",
+            {"CallSid": "CA123"},
+            "invalid",
+            auth_token="test-token",
+        )
+        is False
+    )
+
+
+def test_verify_twilio_signature_rejects_missing_token(monkeypatch):
+    monkeypatch.setattr(security.settings, "twilio_auth_token", None)
+
+    assert (
+        security.verify_twilio_signature(
+            "https://example.com/webhook",
+            {"CallSid": "CA123"},
+            "anything",
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
- used TestGen analyze and dry-run generation for backend security helpers
- added validated pytest coverage for confirmation code generation and Twilio signature verification

## TestGen run
- analyze: 40 files, 54 functions, estimated 36,564 tokens, about /bin/bash.2393 for full repo
- generate dry-run target: backend/app/core/security.py
- provider: Groq llama-3.3-70b-versatile
- usage: 493 input tokens, 321 output tokens, estimated /bin/bash.00054446

## Validation
- cd backend && python3 -m pytest tests/test_security.py -q