### PR TITLE
Make AgentDesk boot in one command with zero keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ AgentDesk is divided into three components:
 2. **Initialize Local Database & Environment:**
    Run the interactive CLI setup wizard to bootstrap the environment variables and SQLite database:
    ```bash
-   python -m cli.init
+   make up
    ```
 
 3. **Backend Setup:**

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# AgentDesk — local OSS quickstart
+# Zero-key by default. Voice is one flag + one key.
+
+COMPOSE = docker compose
+
+.PHONY: setup up voice down logs ps clean
+
+## setup: copy env templates if missing (non-destructive). No keys required to boot.
+setup:
+	@if [ ! -f backend/.env ]; then cp backend/.env.example backend/.env && echo "Created backend/.env (edit to add a voice key later)"; else echo "backend/.env already exists — left untouched"; fi
+	@if [ ! -f frontend/.env ]; then cp frontend/.env.example frontend/.env && echo "Created frontend/.env"; else echo "frontend/.env already exists — left untouched"; fi
+
+## up: boot API + dashboard (no keys, no env file needed). Dashboard at http://localhost:3000
+up:
+	$(COMPOSE) up --build
+
+## voice: boot API + dashboard + the voice worker. Requires a key in backend/.env.
+voice: setup
+	$(COMPOSE) --profile voice up --build
+
+## down: stop everything
+down:
+	$(COMPOSE) down
+
+## logs: follow logs
+logs:
+	$(COMPOSE) logs -f
+
+## ps: show running services
+ps:
+	$(COMPOSE) ps
+
+## clean: stop and wipe the local SQLite volume
+clean:
+	$(COMPOSE) down -v

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # AgentDesk ☎
 
-> **Deploy a custom AI voice receptionist for ANY business in 5 minutes — no database setup required.**
+> **Run a white-label AI voice-agent dashboard locally in ONE command — no database, no keys required to boot.**
 
-AgentDesk is an open-source, white-label voice agent platform. Pick a template, answer 5 questions, and have a live AI phone agent handling real calls.
+AgentDesk is an open-source, white-label voice agent platform. Pick a template, answer 5 questions, and have a live AI phone agent handling real calls. The dashboard, templates, businesses, and API all run with zero configuration; voice needs one API key.
 
 ```bash
-python -m cli.init
+make up
 ```
 
 ---
@@ -18,44 +18,41 @@ python -m cli.init
 | 🧠 **Niche templates** | Restaurant, dental, real estate, HR, e-commerce |
 | 📊 **Dashboard** | Call logs, transcripts, bookings, analytics |
 | 🗄 **Zero-install DB** | SQLite by default — no Postgres/Redis needed |
-| 🌐 **Auto tunnel** | Cloudflare tunnel auto-configured for Twilio |
+| 🐳 **One-command Docker** | `make up` boots API + dashboard, zero keys |
 | 🔒 **Self-hosted** | Your data stays on your server |
 
 ---
 
-## ⚡ Quickstart (5 minutes)
+## ⚡ Quickstart (one command)
 
-### Option A — Interactive Setup Wizard (recommended)
+### Zero-key dashboard (recommended)
 
 ```bash
-# 1. Clone the repo
 git clone https://github.com/princepal9120/agentdesk
 cd agentdesk
+make up
+```
 
-# 2. Run the setup wizard (no dependencies needed!)
-python -m cli.init
+That's it. No `.env` file, no API keys. Open **http://localhost:3000** → dashboard ready. API docs at **http://localhost:8000/docs**.
 
-# 3. Start the backend
-cd backend && uvicorn app.main:app --reload
+### Add voice (one key)
 
-# 4. Start the frontend
+```bash
+cp backend/.env.example backend/.env
+# edit backend/.env and set SARVAM_API_KEY=sk_... (or OPENAI_API_KEY=sk-...)
+make voice
+```
+
+The voice worker only starts with `--profile voice`, so a key-free `make up` never waits on a missing key.
+
+### Legacy manual path (no Docker)
+
+```bash
+# backend
+cd backend && uv pip install --system -e . && uvicorn app.main:app --reload
+# frontend (another terminal)
 cd frontend && npm install && npm run dev
 ```
-
-### Option B — Docker (single command)
-
-```bash
-git clone https://github.com/princepal9120/agentdesk
-cd agentdesk
-
-# Copy and fill in ONLY your Sarvam key
-cp backend/.env.example backend/.env
-# Edit backend/.env and add: SARVAM_API_KEY=sk_...
-
-docker compose up
-```
-
-Open **http://localhost:3000** → dashboard ready.
 
 ---
 
@@ -78,7 +75,7 @@ The setup wizard lets you pick a niche preset. Each template includes a battle-t
 
 ```
 agentdesk/
-├── cli/               # Setup wizard (python -m cli.init)
+├── cli/               # (deprecated) use `make up` for local onboarding
 ├── backend/           # FastAPI + SQLAlchemy + SQLite/Postgres
 │   ├── app/
 │   │   ├── api/       # REST endpoints
@@ -103,13 +100,15 @@ agentdesk/
 
 ## 🔑 Minimum Configuration
 
-Only **one** variable required for local demo:
+**Zero variables required to boot the dashboard.** `make up` runs with no `.env` and no keys.
+
+For voice, set **one** variable in `backend/.env`:
 
 ```env
-SARVAM_API_KEY=sk_...
+SARVAM_API_KEY=sk_...      # or OPENAI_API_KEY=sk-...
 ```
 
-For real US phone calls with the legacy path, add:
+Then run `make voice`. For real US phone calls with the legacy path, add:
 
 ```env
 TWILIO_ACCOUNT_SID=AC...
@@ -139,7 +138,7 @@ used directly without carrier forwarding, SIP/BYOC, or porting.
 1. **`agentdesk init`** — wizard asks your business type, name, website URL, and API keys
 2. Scrapes your website to build an instant knowledge base
 3. Generates a custom system prompt from your template
-4. Auto-configures Twilio webhooks via Cloudflare tunnel
+4. Connects to the local API for dashboard + call logs
 5. Saves everything to local SQLite — no external DB needed
 
 ---

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,48 +1,21 @@
 # AgentDesk Setup
 
-## Recommended path
-
-Start with the local Sarvam end-to-end demo path.
-
-That is the most honest and supported way to experience the repo today.
-
-## What you are setting up
-
-The current launch flow is:
-
-1. landing page at `/`
-2. first-run local setup
-3. dashboard workspace at `/dashboard`
-
-The goal of local setup is to get that flow running quickly without requiring Clerk or a full production telephony stack.
-
-## Requirements
-
-- Docker
-- Docker Compose
-- Sarvam API key
-
-## Quickstart
+## Recommended path (one command)
 
 ```bash
 git clone https://github.com/princepal9120/agentdesk.git
 cd agentdesk
-cp backend/.env.example backend/.env
-cp frontend/.env.example frontend/.env
+make up
 ```
 
-Edit `backend/.env` to at least include:
+That boots the API + dashboard with **no `.env` file and no API keys**. Dashboard: <http://localhost:3000>. API: <http://localhost:8000>.
 
-```env
-SARVAM_API_KEY=sk_...
-VOICE_MODE=demo
-VOICE_PROVIDER=sarvam
-```
-
-Then run:
+To add voice later:
 
 ```bash
-docker compose up --build
+make setup        # copies .env templates if missing
+# edit backend/.env and set SARVAM_API_KEY or OPENAI_API_KEY
+make voice        # starts the voice worker too
 ```
 
 ## Local URLs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,19 @@
-# ══════════════════════════════════════════════════════════════════
-# AgentDesk — Docker Compose
+# ═══════════════════════════════════════════════════════════════════════════
+# AgentDesk — Docker Compose (local OSS quickstart)
 #
-# DEV MODE (default): SQLite + no Redis. Just set SARVAM_API_KEY.
-#   docker compose up
-#   Set SARVAM_API_KEY in backend/.env for the default local voice path.
+# ONE COMMAND, ZERO KEYS:
+#   git clone https://github.com/princepal9120/agentdesk.git
+#   cd agentdesk
+#   make up
 #
-# PROD MODE: Postgres + Redis included.
-#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up
-# ══════════════════════════════════════════════════════════════════
+# That boots the API + dashboard at http://localhost:3000 with NO env file
+# and NO API keys. The dashboard, templates, businesses, and API docs all work.
+#
+# ADD VOICE (needs a SARVAM_API_KEY or OPENAI_API_KEY):
+#   cp backend/.env.example backend/.env   # then set your key
+#   make voice
+#   (or: docker compose --profile voice up --build)
+# ═══════════════════════════════════════════════════════════════════════════
 
 services:
   api:
@@ -18,7 +24,9 @@ services:
     ports:
       - "8000:8000"
     env_file:
-      - ./backend/.env
+      # required:false => boots even when backend/.env is absent (zero-key start)
+      - path: ./backend/.env
+        required: false
     environment:
       # SQLite by default — no database container needed
       DATABASE_URL: sqlite+aiosqlite:////app/data/agentdesk.db
@@ -28,20 +36,12 @@ services:
       - agentdesk_data:/app/data
     command: >
       sh -c "uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
-
-  agent:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    restart: unless-stopped
-    env_file:
-      - ./backend/.env
-    environment:
-      DATABASE_URL: sqlite+aiosqlite:////app/data/agentdesk.db
-      VOICE_MODE: ${VOICE_MODE:-demo}
-    volumes:
-      - agentdesk_data:/app/data
-    command: python run_agent.py
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status==200 else 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
 
   frontend:
     build:
@@ -49,11 +49,34 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - "8001:3000"
+      # Expose on 3000 so the dashboard is at http://localhost:3000 (matches docs)
+      - "3000:3000"
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:8000
     depends_on:
-      - api
+      api:
+        condition: service_healthy
+
+  # OPT-IN voice worker. Off by default so a key-free `make up` never restarts
+  # in a loop waiting for a missing API key. Enable with `make voice`.
+  agent:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    profiles: ["voice"]
+    env_file:
+      - path: ./backend/.env
+        required: false
+    environment:
+      DATABASE_URL: sqlite+aiosqlite:////app/data/agentdesk.db
+      VOICE_MODE: ${VOICE_MODE:-demo}
+    volumes:
+      - agentdesk_data:/app/data
+    command: python run_agent.py
+    depends_on:
+      api:
+        condition: service_healthy
 
 volumes:
   agentdesk_data:


### PR DESCRIPTION
## Problem
The README/SETUP promised "one command `docker compose up`", but the stack actually broke without manual steps:

- `docker-compose.yml` used `env_file: ./backend/.env` with no `required: false`, so `docker compose up` **errored immediately** if `.env` was missing.
- Frontend was mapped `8001:3000` while every doc said `localhost:3000` (wrong URL).
- The `agent` voice worker had `restart: unless-stopped` and exited without a key, causing a **restart loop** in key-free mode.
- Docs referenced `python -m cli.init` (no `cli/` dir exists) and `docker-compose.prod.yml` (doesn't exist).

## Fix
- `docker-compose.yml`: `env_file` now `required: false` → boots with no `.env`. Frontend published on `3000`. Voice worker behind `profiles: ["voice"]`. Added API healthcheck.
- New `Makefile`: `make up` (dashboard, zero keys), `make voice` (adds voice worker), `make setup` (non-destructive `.env` copy), `make down`.
- `README.md` / `SETUP.md` / `CONTRIBUTING.md`: removed stale `cli.init` and `prod` compose references; documented the true one-command path.

## Verification
Built and ran the stack key-free on this machine:
- `docker compose config` → valid
- API container → `healthy`, no `.env`, no keys
- `GET /health` → `{"status":"ok"}`, `/docs` → 200
- Agent worker correctly stays OFF (no restart loop)
- Frontend container serves HTTP 200

Result: `git clone` -> `make up` -> dashboard at http://localhost:3000, no keys, no file edits.

🤖 Generated with Hermes Agent
